### PR TITLE
Corrected Spring setup.

### DIFF
--- a/dxa-framework/dxa-common-api/src/main/java/com/sdl/webapp/common/api/formats/DefaultDataFormatter.java
+++ b/dxa-framework/dxa-common-api/src/main/java/com/sdl/webapp/common/api/formats/DefaultDataFormatter.java
@@ -18,7 +18,6 @@ import java.util.Map;
  * Helper bean to handle the different formatters
  */
 @Component
-@ComponentScan(basePackages = {"com.sdl.webapp.main", "com.sdl.webapp.common.controller", "com.sdl.webapp.addon"})
 public class DefaultDataFormatter implements DataFormatter {
 
     @Autowired

--- a/dxa-framework/dxa-common-api/src/main/resources/META-INF/spring-context.xml
+++ b/dxa-framework/dxa-common-api/src/main/resources/META-INF/spring-context.xml
@@ -8,5 +8,5 @@
                            http://www.springframework.org/schema/context/spring-context.xsd">
 
     <context:annotation-config/>
-    <context:component-scan base-package="com.sdl.webapp.common.api, com.sdl.webapp.common.util"/>
+    <context:component-scan base-package="com.sdl.webapp.common.api, com.sdl.webapp.common.controller, com.sdl.webapp.common.util"/>
 </beans>


### PR DESCRIPTION
Fix to solve an issue with double Spring contexts. This can cause some issues as those contexts are isolated from each other and it also get the effect that some components are initialized twice. This fix needs also correction on the dxa-module-core (see corresponding pull request on https://github.com/sdl/dxa-modules) to make sure that one single Spring context is created instead of two.