### PR TITLE
Upp the DXA-example-webapp DXA version to DXA 1.2

### DIFF
--- a/dxa-example-webapp/pom.xml
+++ b/dxa-example-webapp/pom.xml
@@ -10,7 +10,7 @@
     <packaging>war</packaging>
 
     <properties>
-        <dxa.version>1.2-SNAPSHOT</dxa.version>
+        <dxa.version>1.2</dxa.version>
         <java-version>1.7</java-version>
     </properties>
 


### PR DESCRIPTION
The dxa-example-webapp is looking for DXA 1.2-SNAPSHOT libs while the framework and modules are on DXA 1.2 release.