### PR TITLE
squid:UselessParenthesesCheck,squid:S1155

### DIFF
--- a/dxa-framework/dxa-common-api/src/main/java/com/sdl/webapp/common/api/contextengine/ContextClaims.java
+++ b/dxa-framework/dxa-common-api/src/main/java/com/sdl/webapp/common/api/contextengine/ContextClaims.java
@@ -84,7 +84,7 @@ public abstract class ContextClaims {
                 return null;
             } else {
                 if (Set.class.isInstance(claimValue)) {
-                    Set retval = ((Set) claimValue);
+                    Set retval = (Set) claimValue;
                     ArrayList<T> array = new ArrayList<>();
                     for (Object o : retval) {
                         array.add(castValue(o, cls));

--- a/dxa-framework/dxa-common-api/src/main/java/com/sdl/webapp/common/api/formatters/FeedFormatter.java
+++ b/dxa-framework/dxa-common-api/src/main/java/com/sdl/webapp/common/api/formatters/FeedFormatter.java
@@ -47,7 +47,7 @@ public abstract class FeedFormatter extends BaseFormatter {
      * @return whether a field is a list
      */
     private static boolean isList(SemanticEntity annotation) {
-        return (annotation.vocabulary().equals(SemanticVocabulary.SCHEMA_ORG) && annotation.entityName().equals("ItemList"));
+        return annotation.vocabulary().equals(SemanticVocabulary.SCHEMA_ORG) && annotation.entityName().equals("ItemList");
 
     }
 

--- a/dxa-framework/dxa-common-api/src/main/java/com/sdl/webapp/common/api/model/entity/Image.java
+++ b/dxa-framework/dxa-common-api/src/main/java/com/sdl/webapp/common/api/model/entity/Image.java
@@ -67,7 +67,7 @@ public class Image extends MediaItem {
         return img(getMediaHelper().getResponsiveImageUrl(getUrl(), widthFactor, aspect, containerSize))
                 .withAlt(this.alternateText)
                 .withClass(cssClass)
-                .withAttribute("data-aspect", String.valueOf((Math.round(aspect * 100) / 100)))
+                .withAttribute("data-aspect", String.valueOf(Math.round(aspect * 100) / 100))
                 .withAttribute("width", widthFactor)
                 .build();
     }

--- a/dxa-framework/dxa-common-impl/src/main/java/com/sdl/webapp/common/impl/mapping/SemanticMappingRegistryImpl.java
+++ b/dxa-framework/dxa-common-impl/src/main/java/com/sdl/webapp/common/impl/mapping/SemanticMappingRegistryImpl.java
@@ -288,7 +288,7 @@ public class SemanticMappingRegistryImpl implements SemanticMappingRegistry {
                 }
             }
         }
-        if (possibleValues.size() > 0) {
+        if (!possibleValues.isEmpty()) {
             for (Class<? extends EntityModel> cls : possibleValues) {
                 if (cls.getSimpleName().equals(entityNameSplit[entityNameSplit.length - 1])) {
                     return cls;

--- a/dxa-framework/dxa-common-impl/src/main/java/com/sdl/webapp/common/impl/taglib/dxa/RichTextTag.java
+++ b/dxa-framework/dxa-common-impl/src/main/java/com/sdl/webapp/common/impl/taglib/dxa/RichTextTag.java
@@ -41,7 +41,7 @@ public class RichTextTag extends AbstractMarkupTag {
         StringBuilder builder = new StringBuilder(2048);
         try {
             for (RichTextFragment fragment : content.getFragments()) {
-                EntityModel entityModel = (fragment instanceof EntityModel ? (EntityModel) fragment : null);
+                EntityModel entityModel = fragment instanceof EntityModel ? (EntityModel) fragment : null;
                 String htmlFragment;
                 if (entityModel == null) {
                     htmlFragment = fragment.toHtmlElement().toHtml();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule " UselessParenthesesCheck -     Useless parentheses around expressions should be removed to prevent any misunderstanding, squid:S1155 - Collection.isEmpty() should be used to test for emptiness. You can find more information about the issues here:
https://dev.eclipse.org/sonar/rules/show/squid:S1155
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck


Please let me know if you have any questions.
Sameer Misger