### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/dxa-bom-2013sp1/pom.xml
+++ b/dxa-bom-2013sp1/pom.xml
@@ -560,7 +560,7 @@
             <dependency>
                 <groupId>commons-collections</groupId>
                 <artifactId>commons-collections</artifactId>
-                <version>3.2.1</version>
+                <version>3.2.2</version>
                 <scope>compile</scope>
             </dependency>
 

--- a/dxa-bom-web8/pom.xml
+++ b/dxa-bom-web8/pom.xml
@@ -614,7 +614,7 @@
             <dependency>
                 <groupId>commons-collections</groupId>
                 <artifactId>commons-collections</artifactId>
-                <version>3.2.1</version>
+                <version>3.2.2</version>
                 <scope>compile</scope>
             </dependency>
 

--- a/dxa-framework/pom.xml
+++ b/dxa-framework/pom.xml
@@ -269,7 +269,7 @@
             <dependency>
                 <groupId>commons-collections</groupId>
                 <artifactId>commons-collections</artifactId>
-                <version>3.2.1</version>
+                <version>3.2.2</version>
                 <scope>compile</scope>
             </dependency>
 

--- a/local-project-repo/org/dd4t/dd4t-parent/2.0.2.1-DXA/dd4t-parent-2.0.2.1-DXA.pom
+++ b/local-project-repo/org/dd4t/dd4t-parent/2.0.2.1-DXA/dd4t-parent-2.0.2.1-DXA.pom
@@ -61,7 +61,7 @@
         <!-- versions -->
         <dd4t.version>${project.version}</dd4t.version>
 
-        <commons-collections.version>3.2.1</commons-collections.version>
+        <commons-collections.version>3.2.2</commons-collections.version>
         <commons-io.version>2.4</commons-io.version>
         <commons-codec.version>1.8</commons-codec.version>
         <commons-lang3.version>3.3.2</commons-lang3.version>


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/