### PR TITLE
Respect area name in the include page title. Fixing https://github.co…

### DIFF
--- a/dxa-framework/dxa-tridion-provider/src/main/java/com/sdl/webapp/tridion/mapping/PageBuilderImpl.java
+++ b/dxa-framework/dxa-tridion-provider/src/main/java/com/sdl/webapp/tridion/mapping/PageBuilderImpl.java
@@ -298,7 +298,7 @@ public final class PageBuilderImpl implements PageBuilder {
         if (pageModelType == PageModelImpl.class) {
             // Standard Page Model
             pageModel = new PageModelImpl();
-        } else if (pageMetadataSchema == null) {
+        } else if (pageModelType != null && pageMetadataSchema == null) {
             // Custom Page Model but no Page metadata that can be mapped; simply create a Page Model instance of the right type.
             try {
                 pageModel = (PageModel) pageModelType.newInstance();
@@ -307,7 +307,7 @@ public final class PageBuilderImpl implements PageBuilder {
             } catch (IllegalAccessException e) {
                 throw new DxaException(String.format("Illegal access exception when instantiating new page of type %s", pageModelType), e);
             }
-        } else {
+        } else if(pageMetadataSchema != null){
             // Custom Page Model and Page metadata is present; do full-blown model mapping.
             String[] schemaTcmUriParts = pageMetadataSchema.getId().split("-");
 
@@ -315,6 +315,8 @@ public final class PageBuilderImpl implements PageBuilder {
 
             final Class<? extends ViewModel> entityClass = viewModelRegistry.getMappedModelTypes(semanticSchema.getFullyQualifiedNames());
             pageModel = (PageModel) createViewModel(entityClass, semanticSchema, genericPage);
+        } else {
+            throw new DxaException(String.format("Cannot instantiate new page of template %s", genericPage.getPageTemplate().getTitle()));
         }
 
         pageModel.setId(genericPage.getId());

--- a/dxa-framework/dxa-tridion-provider/src/main/java/com/sdl/webapp/tridion/mapping/PageBuilderImpl.java
+++ b/dxa-framework/dxa-tridion-provider/src/main/java/com/sdl/webapp/tridion/mapping/PageBuilderImpl.java
@@ -112,15 +112,20 @@ public final class PageBuilderImpl implements PageBuilder {
 
     private static RegionModel getRegionFromIncludePage(PageModel page, String includeFileName) {
         try {
+            String regionView = page.getName();
+
             String regionName = page.getName().replace(" ", "-");
+            //if a include page title contains an area name, remove it from the region name, as this name should not be qualified
+            if (regionName.contains(":")) {
+                regionName = regionName.substring(regionName.indexOf(':') + 1);
+            }
 
             MvcData regionMvcData = MvcDataCreator.creator()
-                    .fromQualifiedName(regionName)
+                    .fromQualifiedName(regionView)
                     .defaults(DefaultsMvcData.CORE_REGION)
                     .create();
 
             RegionModelImpl region = new RegionModelImpl(regionName);
-            region.setName(regionName);
             region.setMvcData(regionMvcData);
             ImmutableMap.Builder<String, Object> xpmMetaDataBuilder = ImmutableMap.builder();
 

--- a/dxa-framework/dxa-tridion-provider/src/main/java/com/sdl/webapp/tridion/mapping/PageBuilderImpl.java
+++ b/dxa-framework/dxa-tridion-provider/src/main/java/com/sdl/webapp/tridion/mapping/PageBuilderImpl.java
@@ -113,10 +113,6 @@ public final class PageBuilderImpl implements PageBuilder {
     private static RegionModel getRegionFromIncludePage(PageModel page, String includeFileName) {
         try {
             String regionName = page.getName().replace(" ", "-");
-            //if a include page title contains an area name, remove it from the region name, as this name should not be qualified
-            if (regionName.contains(":")) {
-                regionName = regionName.substring(regionName.indexOf(':') + 1);
-            }
 
             MvcData regionMvcData = MvcDataCreator.creator()
                     .fromQualifiedName(regionName)


### PR DESCRIPTION
See https://github.com/sdl/dxa-web-application-java/issues/34

I tested this on DXA 1.3 and could not find any reason to strip the area name from the page name.

The comment in the old code says  `//if a include page title contains an area name, remove it from the region name, as this name should not be qualified`. But I do not see why it should not be qualified.