### PR TITLE
Corrected the merge of predefined & page based regions.

### DIFF
--- a/dxa-framework/dxa-tridion-provider/src/main/java/com/sdl/webapp/tridion/mapping/PageBuilderImpl.java
+++ b/dxa-framework/dxa-tridion-provider/src/main/java/com/sdl/webapp/tridion/mapping/PageBuilderImpl.java
@@ -152,13 +152,10 @@ public final class PageBuilderImpl implements PageBuilder {
                 continue;
             }
 
-            if (!Objects.equals(predefined.getMvcData(), model.getMvcData())) {
-                LOG.warn("Region '{}' is defined with conflicting MVC data: [{}] and [{}]. Using the former.",
-                        model.getName(), predefined.getMvcData(), model.getMvcData());
-
-                for (EntityModel entityModel : model.getEntities()) {
-                    predefined.addEntity(entityModel);
-                }
+            // Merge regions
+            //
+            for (EntityModel entityModel : model.getEntities()) {
+                predefined.addEntity(entityModel);
             }
         }
 


### PR DESCRIPTION
Solved a problem with page templates having predefined regions, where components on the page belonging to the same region are ignored. For example the 'Section' page template has the 'Main' region predefined, which makes all components belonging to 'Main' region to not show.