### PR TITLE
Log "Page not found" as INFO instead of error

### DIFF
--- a/dxa-framework/dxa-common-api/src/main/java/com/sdl/webapp/common/controller/PageController.java
+++ b/dxa-framework/dxa-common-api/src/main/java/com/sdl/webapp/common/controller/PageController.java
@@ -341,7 +341,7 @@ public class PageController extends BaseController {
         try {
             return contentProvider.getPageModel(path, localization);
         } catch (PageNotFoundException e) {
-            log.error("Page not found: {}", path, e);
+            log.info("Page not found: {}", path, e);
             throw new NotFoundException("Page not found: " + path, e);
         } catch (ContentProviderException e) {
             log.error("An unexpected error occurred", e);


### PR DESCRIPTION
"Page not found" is logged as INFO instead of ERROR