### PR TITLE
Issue #78 - Fixed sporadic issue when a version number is on the link tcm uri

### DIFF
--- a/dxa-framework/dxa-tridion-provider/src/main/java/com/sdl/webapp/tridion/linking/AbstractTridionLinkResolver.java
+++ b/dxa-framework/dxa-tridion-provider/src/main/java/com/sdl/webapp/tridion/linking/AbstractTridionLinkResolver.java
@@ -63,7 +63,7 @@ public abstract class AbstractTridionLinkResolver implements LinkResolver {
         }
 
         final int itemId = Integer.parseInt(parts[1]);
-        final int itemType = parts.length > 2 ? Integer.parseInt(parts[2]) : 16;
+        final int itemType = parts.length > 2 && !parts[2].startsWith("v") ? Integer.parseInt(parts[2]) : 16;
 
         switch (itemType) {
             case 16:


### PR DESCRIPTION
This was breaking the parsing of the uri into integer parts, now we ignore the version part