### PR TITLE
Issue #116 - use context page ID when creating entries in the EntitiesCache

### DIFF
--- a/dxa-framework/dxa-common-api/src/main/java/com/sdl/dxa/caching/wrapper/EntitiesCache.java
+++ b/dxa-framework/dxa-common-api/src/main/java/com/sdl/dxa/caching/wrapper/EntitiesCache.java
@@ -25,6 +25,6 @@ public class EntitiesCache extends SimpleCacheWrapper<EntityModelData, EntityMod
 
     @Override
     public LocalizationAwareCacheKey getSpecificKey(EntityModelData entityModelData, Object... other) {
-        return getKey(entityModelData.getId(), entityModelData.getSchemaId(), entityModelData.getMvcData());
+        return getKey(entityModelData.getId(), entityModelData.getContextId(), entityModelData.getSchemaId(), entityModelData.getMvcData());
     }
 }

--- a/dxa-framework/dxa-common-api/src/test/java/com/sdl/dxa/caching/wrapper/CacheTest.java
+++ b/dxa-framework/dxa-common-api/src/test/java/com/sdl/dxa/caching/wrapper/CacheTest.java
@@ -65,7 +65,7 @@ public class CacheTest {
         MvcModelData mvcData = new MvcModelData("a", "a", "a", "c", "v", null);
         PageModelData pageData = (PageModelData) new PageModelData("1", null, null, null, null, null, "/url")
                 .setMvcData(mvcData);
-        EntityModelData entityMvcData = (EntityModelData) new EntityModelData("2", null, null, null, null, mvcData, "1", "/url", null, null, null)
+        EntityModelData entityMvcData = (EntityModelData) new EntityModelData("3", null, null, null, null, mvcData, "1", "2", "/url", null, null, null)
                 .setMvcData(mvcData);
 
         //when
@@ -74,7 +74,7 @@ public class CacheTest {
 
         //then
         assertEquals(keyGenerator.generate("/url", mvcData), pagesCopyingCacheKey);
-        assertEquals(keyGenerator.generate("1", "2", mvcData), entitiesCacheKey);
+        assertEquals(keyGenerator.generate("1", "2", "3", mvcData), entitiesCacheKey);
     }
 
     private void shouldReturnNeededCache(Supplier<SimpleCacheWrapper<?, ?>> supplier, String cacheName) {

--- a/dxa-framework/dxa-common/src/main/java/com/sdl/dxa/common/dto/EntityRequestDto.java
+++ b/dxa-framework/dxa-common/src/main/java/com/sdl/dxa/common/dto/EntityRequestDto.java
@@ -23,6 +23,8 @@ public class EntityRequestDto {
 
     private int templateId;
 
+    private int contextId;//The context page id (if applicable)
+
     /**
      * DXA format of entity ID contains component and template IDs separated with "{@code -}".
      */
@@ -44,6 +46,10 @@ public class EntityRequestDto {
 
     public static EntityRequestDtoBuilder builder(int publicationId, String entityId) {
         return hiddenBuilder().publicationId(publicationId).entityId(entityId);
+    }
+
+    public static EntityRequestDtoBuilder builder(int publicationId, String entityId, int contextId) {
+        return hiddenBuilder().publicationId(publicationId).entityId(entityId, contextId);
     }
 
     public static EntityRequestDtoBuilder builder(int publicationId, int componentId) {
@@ -88,6 +94,8 @@ public class EntityRequestDto {
 
         private ContentType contentType = ContentType.MODEL;
 
+        private int contextId = -1;
+
         private EntityRequestDtoBuilder() {
         }
 
@@ -100,6 +108,10 @@ public class EntityRequestDto {
         }
 
         public EntityRequestDtoBuilder entityId(@NotNull String entityId) {
+            return entityId(entityId, contextId);
+        }
+
+        public EntityRequestDtoBuilder entityId(@NotNull String entityId, int contextId) {
             Assert.isTrue(entityId.matches("\\d+-\\d+"), "Entity ID should be of format CompId-TemplateId");
             List<String> parts = Splitter.on("-").splitToList(entityId);
             int componentId = Integer.parseInt(parts.get(0));
@@ -108,6 +120,7 @@ public class EntityRequestDto {
             this.entityId = templateId == 0 ? parts.get(0) : entityId;
             this.componentId = componentId;
             this.templateId = templateId;
+            this.contextId = contextId;
             return this;
         }
     }

--- a/dxa-framework/dxa-common/src/main/java/com/sdl/webapp/common/api/content/LinkResolver.java
+++ b/dxa-framework/dxa-common/src/main/java/com/sdl/webapp/common/api/content/LinkResolver.java
@@ -22,8 +22,9 @@ public interface LinkResolver {
      * @return The translated URL.
      */
     @Contract("null, _, _ -> null; !null, _, _ -> !null")
-    String resolveLink(@Nullable String url, @Nullable String localizationId, boolean resolveToBinary);
-
+    default String resolveLink(@Nullable String url, @Nullable String localizationId, boolean resolveToBinary){
+        return resolveLink(url, localizationId, resolveToBinary, null);
+    }
     /**
      * Resolves a link. This translates the input URL to a link that can be used on a web page. What the input URL
      * is exactly depends on the implementation and what the source of the data is - it might for example be a Tridion
@@ -35,6 +36,36 @@ public interface LinkResolver {
      */
     @Contract("null, _ -> null; !null, _ -> !null")
     default String resolveLink(@Nullable String url, @Nullable String localizationId) {
-        return resolveLink(url, localizationId, false);
+        return resolveLink(url, localizationId, false, null);
     }
+
+    /**
+     * Resolves a link. This translates the input URL to a link that can be used on a web page. What the input URL
+     * is exactly depends on the implementation and what the source of the data is - it might for example be a Tridion
+     * "tcm:" URL which refers to a Tridion component.
+     *
+     * @param url            The TCM URI to resolve.
+     * @param localizationId The localization ID to use.
+     * @param contextId The ID of the context page within which we are resolving
+     * @return The translated URL.
+     */
+    @Contract("null, _, _ -> null; !null, _, _ -> !null")
+    default String resolveLink(@Nullable String url, @Nullable String localizationId, @Nullable String contextId) {
+        return resolveLink(url, localizationId, false, contextId);
+    }
+
+    /**
+     * Resolves a link. This translates the input URL to a link that can be used on a web page. What the input URL
+     * is exactly depends on the implementation and what the source of the data is - it might for example be a Tridion
+     * "tcm:" URL which refers to a Tridion component.
+     *
+     * @param url             The TCM URI to resolve.
+     * @param localizationId  The localization ID to use.
+     * @param resolveToBinary whether the expected URL is an URL to a binary
+     * @param contextId The ID of the context page within which we are resolving
+     * @return The translated URL.
+     */
+    @Contract("null, _, _, _ -> null; !null, _, _, _ -> !null")
+    String resolveLink(@Nullable String url, @Nullable String localizationId, boolean resolveToBinary, @Nullable String contextId);
+
 }

--- a/dxa-framework/dxa-common/src/main/java/com/sdl/webapp/tridion/linking/AbstractLinkResolver.java
+++ b/dxa-framework/dxa-common/src/main/java/com/sdl/webapp/tridion/linking/AbstractLinkResolver.java
@@ -7,6 +7,7 @@ import com.sdl.webapp.common.util.TcmUtils;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.Nullable;
 import org.springframework.beans.factory.annotation.Value;
@@ -37,21 +38,28 @@ public abstract class AbstractLinkResolver implements LinkResolver {
     private boolean shouldStripIndexPath;
 
     @Override
-    @Cacheable(value = "defaultCache", key = "{ #root.methodName,  #url, #localizationId, #resolveToBinary }")
-    public String resolveLink(@Nullable String url, @Nullable String localizationId, boolean resolveToBinary) {
+    @Cacheable(value = "defaultCache", key = "{ #root.methodName,  #url, #localizationId, #resolveToBinary, #contextId }")
+    public String resolveLink(@Nullable String url, @Nullable String localizationId, boolean resolveToBinary, @Nullable String contextId) {
         final int publicationId = !Strings.isNullOrEmpty(localizationId) ? Integer.parseInt(localizationId) : 0;
 
-        String resolvedLink = _resolveLink(url, publicationId, resolveToBinary);
+        String resolvedLink = _resolveLink(url, publicationId, resolveToBinary, contextId);
         String resolvedUrl = shouldStripIndexPath ? PathUtils.stripIndexPath(resolvedLink) : resolvedLink;
         return shouldRemoveExtension ? PathUtils.stripDefaultExtension(resolvedUrl) : resolvedUrl;
     }
 
     @Contract("null, _, _ -> null; !null, _, _ -> !null")
-    private String _resolveLink(String uri, int publicationId, boolean isBinary) {
+    private String _resolveLink(String uri, int publicationId, boolean isBinary, String contextId) {
         if (uri == null || !TcmUtils.isTcmUri(uri)) {
             return uri;
         }
-
+        //Page ID is either tcm uri or int (in string form) -1 means no page context
+        int pageId = -1;
+        if (contextId != null && TcmUtils.isTcmUri(contextId)) {
+            pageId = TcmUtils.getItemId(contextId);
+        }
+        else{
+            pageId = NumberUtils.toInt(contextId,-1);
+        }
         Function<ResolvingData, Optional<String>> resolver;
         switch (TcmUtils.getItemType(uri)) {
             case TcmUtils.COMPONENT_ITEM_TYPE:
@@ -67,7 +75,7 @@ public abstract class AbstractLinkResolver implements LinkResolver {
 
         ResolvingData resolvingData = ResolvingData.of(
                 publicationId == 0 ? TcmUtils.getPublicationId(uri) : publicationId,
-                TcmUtils.getItemId(uri), uri);
+                TcmUtils.getItemId(uri), uri, pageId);
 
         return resolver.apply(resolvingData).orElse("");
     }
@@ -94,5 +102,7 @@ public abstract class AbstractLinkResolver implements LinkResolver {
         private int itemId;
 
         private String uri;
+
+        private int pageId;
     }
 }

--- a/dxa-framework/dxa-data-model/src/main/java/com/sdl/dxa/api/datamodel/model/EntityModelData.java
+++ b/dxa-framework/dxa-data-model/src/main/java/com/sdl/dxa/api/datamodel/model/EntityModelData.java
@@ -9,6 +9,7 @@ import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.Accessors;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.Map;
 
@@ -22,6 +23,8 @@ public class EntityModelData extends ViewModelData implements CanWrapContentAndM
 
     private String id;
 
+    private String contextId;
+
     private ComponentTemplateData componentTemplate;
 
     private String linkUrl;
@@ -33,22 +36,24 @@ public class EntityModelData extends ViewModelData implements CanWrapContentAndM
     private ExternalContentData externalContent;
 
     @Builder
-    public EntityModelData(String schemaId, String htmlClasses, Map<String, Object> xpmMetadata, ContentModelData metadata, Map<String, Object> extensionData, MvcModelData mvcData, String id, String linkUrl, ContentModelData content, BinaryContentData binaryContent, ExternalContentData externalContent) {//NOSONAR
+    public EntityModelData(String schemaId, String htmlClasses, Map<String, Object> xpmMetadata, ContentModelData metadata, Map<String, Object> extensionData, MvcModelData mvcData, String id, String contextId, String linkUrl, ContentModelData content, BinaryContentData binaryContent, ExternalContentData externalContent) {//NOSONAR
         super(schemaId, htmlClasses, xpmMetadata, metadata, extensionData, mvcData);
         this.id = id;
         this.linkUrl = linkUrl;
         this.content = content;
         this.binaryContent = binaryContent;
         this.externalContent = externalContent;
+        this.contextId = contextId;
     }
 
     @Builder
-    public EntityModelData(String id, String linkUrl, ContentModelData content, BinaryContentData binaryContent, ExternalContentData externalContent) {
+    public EntityModelData(String id, String contextId, String linkUrl, ContentModelData content, BinaryContentData binaryContent, ExternalContentData externalContent) {
         this.id = id;
         this.linkUrl = linkUrl;
         this.content = content;
         this.binaryContent = binaryContent;
         this.externalContent = externalContent;
+        this.contextId = contextId;
     }
 
     @Override
@@ -77,10 +82,14 @@ public class EntityModelData extends ViewModelData implements CanWrapContentAndM
 
         EntityModelData emd = (EntityModelData) other;
         this.id = emd.id;
+        this.contextId = emd.contextId;
         this.linkUrl = emd.linkUrl;
         this.content = emd.content;
         this.binaryContent = emd.binaryContent;
         this.externalContent = emd.externalContent;
         return this;
     }
+
+    public String getContextId() { return StringUtils.isNotEmpty(contextId) ? contextId : "0";}
+
 }

--- a/dxa-framework/dxa-data-model/src/test/java/com/sdl/dxa/api/datamodel/processing/DataModelDeepFirstSearcherTest.java
+++ b/dxa-framework/dxa-data-model/src/test/java/com/sdl/dxa/api/datamodel/processing/DataModelDeepFirstSearcherTest.java
@@ -29,7 +29,7 @@ public class DataModelDeepFirstSearcherTest {
         PageModelData page = (PageModelData) new PageModelData()
                 .setId("p")
                 .setRegions(Lists.newArrayList(new RegionModelData(null, null,
-                        Lists.newArrayList(new EntityModelData(null, null, null, metadata, null, null, "e", null, content, null, null)),
+                        Lists.newArrayList(new EntityModelData(null, null, null, metadata, null, null, "e", null, null, content, null, null)),
                         Lists.newArrayList(new RegionModelData(null, null, null, metadata, null, null, null, null, null, null)))))
                 .setMetadata(metadata);
 

--- a/dxa-framework/dxa-tridion-common/src/main/java/com/sdl/dxa/tridion/linking/TridionLinkResolver.java
+++ b/dxa-framework/dxa-tridion-common/src/main/java/com/sdl/dxa/tridion/linking/TridionLinkResolver.java
@@ -15,7 +15,7 @@ public class TridionLinkResolver extends AbstractLinkResolver {
     @Override
     protected Function<ResolvingData, Optional<String>> _componentResolver() {
         return resolvingData -> Optional.ofNullable(
-                new ComponentLinkImpl(resolvingData.getPublicationId()).getLink(resolvingData.getItemId()).getURL());
+                new ComponentLinkImpl(resolvingData.getPublicationId()).getLink(resolvingData.getPageId(), resolvingData.getItemId(), -1, null, "", false, false).getURL());
     }
 
     @Override

--- a/dxa-framework/dxa-tridion-provider/src/test/java/com/sdl/dxa/tridion/mapping/impl/ModelBuilderPipelineTest.java
+++ b/dxa-framework/dxa-tridion-provider/src/test/java/com/sdl/dxa/tridion/mapping/impl/ModelBuilderPipelineTest.java
@@ -42,7 +42,7 @@ public class ModelBuilderPipelineTest {
 
     private PageModelData pageModelData = new PageModelData("1", null, null, null, "title", null, null);
 
-    private EntityModelData entityModelData = new EntityModelData("1", "url", null, null, null);
+    private EntityModelData entityModelData = new EntityModelData("1", "2", "url", null, null, null);
 
     private PageModel firstPageModel = new DefaultPageModel();
 


### PR DESCRIPTION
Note this also contains merged code for the fix for issue #104 (which can also be found in PR #114) as this is pre-requisite for the model service part of this fix (see https://github.com/sdl/dxa-model-service/pull/8)